### PR TITLE
Retry Function Shouldn't Retry in the Middle of Exeuction

### DIFF
--- a/executors/default/pkg/status/polling.go
+++ b/executors/default/pkg/status/polling.go
@@ -7,19 +7,6 @@ import (
 	"time"
 )
 
-// Retry retries the passed retryable function, sleeping for the given backoffDuration
-// If the context times out while executing the retryable function, an error is returned
-func Retry(ctx context.Context, retryable func() error, backoffDuration time.Duration) error {
-	pollingFunc := func(done chan<- bool) {
-		if err := retryable(); err != nil {
-			log.Errorf("Failed to execute the retryable function with: %v", err)
-		}
-		log.Infof("successfully completed the retry function")
-		done <- true
-	}
-	return Poll(ctx, pollingFunc, backoffDuration)
-}
-
 // Poll retries the poller function, sleeping for the given backoffDuration
 // If the poller times out it will return an error
 func Poll(ctx context.Context, poller func(chan<- bool), backoffDuration time.Duration) error {

--- a/executors/default/pkg/status/retry.go
+++ b/executors/default/pkg/status/retry.go
@@ -1,0 +1,27 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+// Retry retries the passed retryable function, sleeping for the given backoffDuration
+// If the context times out while executing the retryable function, an error is returned
+func Retry(ctx context.Context, retryable func() error, backoffDuration time.Duration) error {
+	for {
+		if err := retryable(); err != nil {
+			log.Errorf("Failed to execute the retryable function with: %v", err)
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to complete retry function within the timeout")
+			default:
+				time.Sleep(backoffDuration)
+			}
+		} else {
+			log.Infof("successfully completed the retry function")
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
Currently, retry leverages poll which polls at a fixed interval, retry shouldn't have overlapping calls, so it should use a different mechanism